### PR TITLE
Remove dependency that forces an unneeded patch onto dependent projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "prefer-stable": true,
     "require": {
         "drupal/geocoder": "^3.0",
-        "openeuropa/drupal-core-require": "^8.6",
         "openeuropa/webtools-geocoding-provider": "~0.1",
         "php": "^7.1"
     },


### PR DESCRIPTION
For some unknown reason a dependency was added to the project which forces a patch regarding interface language detection onto the projects that use this module.

This component has nothing to do with interface translation so this patch is completely unneeded. The presence of this dependency is causing failures in my project:

* My project depends on Drupal 8.6.3 which the dependency prevents from being installed, instead forcing us onto the pre-alpha 8.7.x!
* Our site is not multilingual and we have absolutely no need to get unfinished patches related to interface translation forced unto us.